### PR TITLE
Custom query for API monitoring

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "monitor_latency_p95" {
   name               = "${var.latency_p95_name != "" ? 
                         "${var.latency_p95_name}" :
                         "${var.product_domain} - ${var.cluster} - ${var.environment} - API Latency is High on Class: {{ classname }} Method: {{ methodname }}"}"
-  query              = "avg(last_1m):avg:api.res.ltcy.p95{cluster:${var.cluster}, environment:${var.environment}} by {host,classname,methodname} >= ${var.latency_p95_thresholds["critical"]}"
+  query              = "${coalesce(var.api_latency_p95_custom_query, "avg(last_1m):avg:api.res.ltcy.p95{cluster:${var.cluster}, environment:${var.environment}} by {host,classname,methodname} >= ${var.latency_p95_thresholds["critical"]}")}"
   thresholds         = "${var.latency_p95_thresholds}"
   message            = "${var.latency_p95_message}"
   escalation_message = "${var.latency_p95_escalation_message}"
@@ -117,7 +117,7 @@ module "monitor_exception" {
   name               = "${var.exception_name != "" ? 
                         "${var.exception_name}" :
                         "${var.product_domain} - ${var.cluster} - ${var.environment} - API Exception is High on Class: {{ classname }} Method: {{ methodname }}"}"
-  query              = "avg(${var.monitor_exception_time_evaluation}):sum:api.res.exc.count{cluster:${var.cluster}, environment:${var.environment}} by {host,classname,methodname} >= ${var.exception_thresholds["critical"]}"
+  query              = "${coalesce(var.api_exception_custom_query, "avg(${var.monitor_exception_time_evaluation}):sum:api.res.exc.count{cluster:${var.cluster}, environment:${var.environment}} by {host,classname,methodname} >= ${var.exception_thresholds["critical"]}")}"
   thresholds         = "${var.exception_thresholds}"
   message            = "${var.exception_message}"
   escalation_message = "${var.exception_escalation_message}"

--- a/variables.tf
+++ b/variables.tf
@@ -134,3 +134,15 @@ variable "monitor_exception_time_evaluation" {
   default     = "last_1m"
   description = "time window evaluation that triggers an alert for API Exception"
 }
+
+variable "api_latency_p95_custom_query" {
+  type        = "string"
+  default     = ""
+  description = "The custom query for API Latency P95 monitoring"
+}
+
+variable "api_exception_custom_query" {
+  type        = "string"
+  default     = ""
+  description = "The custom query for API Response Exception monitoring"
+}


### PR DESCRIPTION
## Background
We need custom query for API Latency P95 and API Exception.
One of example custom query: `avg(last_1m):sum:api.res.exc.count{cluster:xxxxxx-app, environment:production, !methodname:xxx1, !methodname:xxx2} by {host,classname,methodname} >= 10`

## Test Plan
- Tested on locally

Terraform plan:
Without custom query variables (`api_latency_p95_custom_query` & `api_exception_custom_query` )
```
No changes.
```

With custom query variables
```
~ module.api.module.monitor_exception.datadog_monitor.template
    query:   "avg(last_1m):sum:api.res.exc.count{cluster:xxxxxx-app, environment:production} by {host,classname,methodname} >= 10" => "avg(last_1m):sum:api.res.exc.count{cluster:xxxxxx-app, environment:production, !methodname:xxx1, !methodname:xxx2} by {host,classname,methodname} >= 10"
~ module.api.module.monitor_latency_p95.datadog_monitor.template
    query:   "avg(last_1m):avg:api.res.ltcy.p95{cluster:xxxxxx-app, environment:production} by {host,classname,methodname} >= 1500" => "avg(last_1m):avg:api.res.ltcy.p95{cluster:xxxxxx-app, environment:production, !methodname:xxx1, !methodname:xxx2} by {host,classname,methodname} >= 1500"
Plan: 0 to add, 2 to change, 0 to destroy.
```

## References
- https://www.terraform.io/docs/configuration/functions/coalesce.html
