### PR TITLE
fix: use avg for latency 95th percentile

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "datadog_dashboard" "api" {
       title = "API Response Latency 95th Percentile"
 
       request {
-        q            = "sum:api.res.ltcy.p95{$cluster, $environment} by {host, classname, methodname}"
+        q            = "avg:api.res.ltcy.p95{$cluster, $environment} by {host, classname, methodname}"
         display_type = "line"
       }
     }


### PR DESCRIPTION
This PR fixes the query for latency 95th percentile, where it should use `avg` instead of `sum`.